### PR TITLE
fix cmake POST_BUILD copy_directory issue

### DIFF
--- a/viewer/app/CMakeLists.txt
+++ b/viewer/app/CMakeLists.txt
@@ -4,6 +4,9 @@ project(
     VERSION 1.0
     LANGUAGES CXX C)
 
+# Define the output path for ImGUI bindings (default: <build>/bin).
+set(MCD_BINARY_PATH "${CMAKE_BINARY_DIR}/bin" CACHE PATH "Binary output path for ImGUI bindings")
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
 
 # ImGUI bindings to Vulkan and SDL2.
@@ -82,7 +85,7 @@ target_compile_definitions(
 
 # Move the ImGUI files to the binaries folder.
 add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/viewer/external/ImGUI/Bindings/include" "$ENV{MCD_BINARY_PATH}"
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/viewer/external/ImGUI/Bindings/include" "${MCD_BINARY_PATH}"
     COMMENT "Copying ImGUI files to build directory.")
 
 # There are issues on Apple platforms with exceptions and -fno-rtti, so keep it


### PR DESCRIPTION
There was a bug: When I change one of the CMakeLists to trigger reconfiguration, then make will yield:
Copying ImGUI files to build directory. CMake Error: cmake version 3.28.3 Usage: /usr/bin/cmake -E <command> [arguments...] Available commands:  capabilities              - Report capabilities built into cmake in JSON format cat [--] <files>...       - concat the files and print them to the standard output chdir dir cmd [args...]   - run command in a given directory compare_files [--ignore-eol] file1 file2 - check if file1 i ...

I was able to reproduce the previously reported build error that occurred when $ENV{MCD_BINARY_PATH} was not set. The POST_BUILD command for copying the ImGUI bindings used an empty environment variable as the target path.